### PR TITLE
🔧fix(woocommerce_requests): import `get_time_zone` 

### DIFF
--- a/woocommerceconnector/woocommerce_requests.py
+++ b/woocommerceconnector/woocommerce_requests.py
@@ -3,7 +3,8 @@ import frappe
 from frappe import _
 import json, math, time, pytz
 from .exceptions import woocommerceError
-from frappe.utils import get_request_session, get_datetime, get_time_zone
+from frappe.utils import get_request_session, get_datetime
+from frappe.client import get_time_zone
 from woocommerce import API
 from .utils import make_woocommerce_log
 import requests


### PR DESCRIPTION
Closes #1 